### PR TITLE
Add the celery background worker to render.yaml

### DIFF
--- a/render-build.sh
+++ b/render-build.sh
@@ -4,4 +4,7 @@ set -e # exit on error
 export RSA_PRIVATE_KEY=$(cat /etc/secrets/saleor-key)
 
 pip3 install -r requirements.txt
-python manage.py migrate --no-input
+
+if [ "$RENDER_SERVICE_TYPE" = "web" ]; then
+  python manage.py migrate --no-input
+fi

--- a/render-start.sh
+++ b/render-start.sh
@@ -7,6 +7,15 @@ python -c 'import os; print(os.environ.get("ALLOWED_HOSTS"))'
 echo $ALLOWED_HOSTS
 echo $RENDER_EXTERNAL_HOSTNAME
 
-gunicorn --bind :$PORT --workers 4 --worker-class uvicorn.workers.UvicornWorker saleor.asgi:application
-
-python manage.py populatedb --createsuperuser --withoutimages
+subcommand=$1
+case $subcommand in
+  server)
+    gunicorn --bind :$PORT --workers 4 --worker-class uvicorn.workers.UvicornWorker saleor.asgi:application
+    ;;
+  worker)
+    celery -A saleor --app=saleor.celeryconf:app worker --loglevel=info -E
+    ;;
+  *)
+    echo "Unknown subcommand"
+    ;;
+esac

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     env: python
     repo: https://github.com/dnilasor/saleor
     buildCommand: ./render-build.sh
-    startCommand: ./render-start.sh
+    startCommand: ./render-start.sh server
     envVars:
       - key: DJANGO_SETTINGS_MODULE
         value: saleor.settings

--- a/render.yaml
+++ b/render.yaml
@@ -6,18 +6,6 @@ services:
     buildCommand: ./render-build.sh
     startCommand: ./render-start.sh server
     envVars:
-      - key: DJANGO_SETTINGS_MODULE
-        value: saleor.settings
-      - key: DEBUG
-        value: True
-      - key: NPM_CONFIG_PRODUCTION
-        value: false
-      - key: DEFAULT_FROM_EMAIL
-        value: noreply@example.com
-      - key: ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL
-        value: False
-      - key: SECRET_KEY
-        generateValue: true
       - key: DATABASE_URL
         fromDatabase:
           name: saelor-db
@@ -27,8 +15,6 @@ services:
           type: redis
           name: saelor-redis
           property: connectionString
-      - key: PYTHON_VERSION
-        value: 3.9.0
       - key: ALLOWED_CLIENT_HOSTS
         value: "*"
 #        - key: AWS_MEDIA_BUCKET_NAME
@@ -37,6 +23,8 @@ services:
 #          value:
 #        - key: AWS_SECRET_ACCESS_KEY
 #          value: 
+      - fromGroup: saleor-settings
+
   - type: redis
     name: saelor-redis
     ipAllowList: [] # only allow internal connections
@@ -52,5 +40,25 @@ services:
 databases:
     - name: saelor-db
       ipAllowList: [] # only allow internal connections
+
+envVarGroups:
+  - name: saleor-settings
+    envVars:
+      - key: PYTHON_VERSION
+        value: 3.9.0
+      - key: DJANGO_SETTINGS_MODULE
+        value: saleor.settings
+      - key: DEBUG
+        value: True
+      - key: NPM_CONFIG_PRODUCTION
+        value: false
+      - key: DEFAULT_FROM_EMAIL
+        value: noreply@example.com
+      - key: ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL
+        value: False
+      - key: SECRET_KEY
+        generateValue: true
+
+
 
 # python manage.py migrate && python manage.py populatedb --createsuperuser --withoutimages

--- a/render.yaml
+++ b/render.yaml
@@ -25,6 +25,24 @@ services:
 #          value: 
       - fromGroup: saleor-settings
 
+  - type: worker
+    name: celery-worker
+    env: python
+    repo: https://github.com/dnilasor/saleor
+    buildCommand: ./render-build.sh
+    startCommand: ./render-start.sh worker
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: saelor-db
+          property: connectionString
+      - key: REDIS_URL
+        fromService:
+          type: redis
+          name: saelor-redis
+          property: connectionString
+      - fromGroup: saleor-settings
+
   - type: redis
     name: saelor-redis
     ipAllowList: [] # only allow internal connections

--- a/render.yaml
+++ b/render.yaml
@@ -29,6 +29,7 @@ services:
     name: celery-worker
     env: python
     repo: https://github.com/dnilasor/saleor
+    plan: standard #TODO: investigate how to configure celery so that it does not need 2GB of RAM
     buildCommand: ./render-build.sh
     startCommand: ./render-start.sh worker
     envVars:


### PR DESCRIPTION
This required a few other changes to add cleanly. See commit sequence in this branch for more details. Changes I made:

1. Edit start script to allow a subcommand so same script can be used to start the server or the worker process
2. Moved some env vars to an env var group so they can be shared between the web service and the background worker service
3. Added the actual background worker service
4. Edit build script so that DB migration only runs for web service. I noticed it was erroring out while running as part of the build of the background worker because the migrations were also in the process of being run as part of the web service build. It's ok to run the migration on every future deploy, but it looks like two or more concurrent migrations will cause a race condition and one of them will error out.
5. Worker ran out of memory so I changed the plan to `standard` (2GB). I'm kind of surprised celery doesn't work with 512MB, but it's mostly dependent on the tasks it's performing and I didn't dig into them. I left a `TODO` comment next to the plan name in the render.yaml to investigate configuring celery so that it doesn't need so much memory.

Note that using the environment group requires a change to the initial deploy process. The rsa key in the secret file should now be added in the *environment group* not in an individual service. This makes it available to both the web service and the background worker.